### PR TITLE
Added +parametersForURL: method

### DIFF
--- a/JLRoutes/JLRoutes.h
+++ b/JLRoutes/JLRoutes.h
@@ -43,6 +43,9 @@ static NSString *const kJLRoutesGlobalNamespaceKey = @"JLRoutesGlobalNamespace";
 /// Routes a URL, calling handler blocks (for patterns that match URL) until one returns YES.
 + (BOOL)routeURL:(NSURL *)URL;
 
+/// Returns matched parameters for first route it finds without calling any route blocks.
++ (NSDictionary*)parametersForURL:(NSURL *)URL;
+
 /// Controls whether or not this routes controller will try to match a URL with global routes if it can't be matched in the current namespace. Default is NO.
 @property (assign) BOOL shouldFallbackToGlobalRoutes;
 


### PR DESCRIPTION
While messing with this library I found it could be useful to parse the URL for the parameters but without actually calling the routing blocks. This is similar to the `recongize_path` method in Rails.

In doing so I refactored one small thing, which is to pull the `pathComponents` array out of the `+routeURL:` method and stick it in the `-parametersForURL:` method. Seems like a better place for that logic, and this way it can be shared.

Let me know if this is useful or if you want me to change something.
