### PR TITLE
subscripting for JLRoutes

### DIFF
--- a/JLRoutes/JLRoutes.h
+++ b/JLRoutes/JLRoutes.h
@@ -35,6 +35,9 @@ static NSString *const kJLRoutesGlobalNamespaceKey = @"JLRoutesGlobalNamespace";
 + (void)addRoute:(NSString *)routePattern handler:(BOOL (^)(NSDictionary *parameters))handlerBlock;
 - (void)addRoute:(NSString *)routePattern handler:(BOOL (^)(NSDictionary *parameters))handlerBlock; // instance method
 
+/// Registers a routePattern with default priority (0) using dictionary-style subscripting.
+- (void)setObject:(id)handlerBlock forKeyedSubscript:(NSString *)routePatten;
+
 /// Registers a routePattern in the global scheme namespace with a handlerBlock to call when the route pattern is matched by a URL.
 /// The block returns a BOOL representing if the handlerBlock actually handled the route or not. If
 /// a block returns NO, JLRoutes will continue trying to find a matching route.

--- a/JLRoutes/JLRoutes.m
+++ b/JLRoutes/JLRoutes.m
@@ -371,5 +371,11 @@ static BOOL verboseLoggingEnabled = NO;
 	}
 }
 
+#pragma mark -
+#pragma mark Subscripting
+
+- (void)setObject:(id)handlerBlock forKeyedSubscript:(NSString *)routePatten {
+  [self addRoute:routePatten handler:handlerBlock];
+}
 
 @end

--- a/JLRoutesTests/JLRoutesTests.m
+++ b/JLRoutesTests/JLRoutesTests.m
@@ -256,6 +256,17 @@ static JLRoutesTests *testsInstance = nil;
     STAssertFalse([JLRoutes canRouteURL:shouldNotHaveRouteURL], @"Should not state it can route unknown URL");
 }
 
+- (void)testSubscripting {
+  JLRoutes.globalRoutes[@"/subscripting"] = ^BOOL(NSDictionary *parameters) {
+		testsInstance.lastMatch = parameters;
+		return YES;
+	};
+
+  NSURL *shouldHaveRouteURL = [NSURL URLWithString:@"subscripting"];
+
+  STAssertTrue([JLRoutes canRouteURL:shouldHaveRouteURL], @"Should state it can route known URL");
+}
+
 #pragma mark -
 #pragma mark Convenience Methods
 


### PR DESCRIPTION
Not sure if this is something that is desired, but this allows dictionary style subscripting syntax to JLRoute instances for quickly registering route handlers:

``` objective-c
JLRoutes.globalRoutes[@"/subscripting"] = ^BOOL(NSDictionary *parameters) {
  testsInstance.lastMatch = parameters;
  return YES;
};
```
