### PR TITLE
Added support for routing to specific routers

### DIFF
--- a/JLRoutes/JLRoutes.h
+++ b/JLRoutes/JLRoutes.h
@@ -55,6 +55,9 @@ static NSString *const kJLRoutesGlobalNamespaceKey = @"JLRoutesGlobalNamespace";
 + (BOOL)canRouteURL:(NSURL *)URL;
 + (BOOL)canRouteURL:(NSURL *)URL withParameters:(NSDictionary *)parameters;
 
+- (BOOL)canRouteURL:(NSURL *)URL;
+- (BOOL)canRouteURL:(NSURL *)URL withParameters:(NSDictionary *)parameters;
+
 /// Prints the entire routing table
 + (NSString *)description;
 

--- a/JLRoutes/JLRoutes.m
+++ b/JLRoutes/JLRoutes.m
@@ -242,14 +242,21 @@ static BOOL verboseLoggingEnabled = NO;
 	return [self routeURL:URL withController:routesController parameters:parameters executeBlock:execute];
 }
 
-- (BOOL)routeURL:(NSURL *)url {
-	return [[self class] routeURL:url withController:self];
+- (BOOL)routeURL:(NSURL *)URL {
+	return [[self class] routeURL:URL withController:self];
 }
 
-- (BOOL)routeURL:(NSURL *)url withParameters:(NSDictionary *)parameters {
-	return [[self class] routeURL:url withController:self parameters:parameters];
+- (BOOL)routeURL:(NSURL *)URL withParameters:(NSDictionary *)parameters {
+	return [[self class] routeURL:URL withController:self parameters:parameters];
 }
 
+- (BOOL)canRouteURL:(NSURL *)URL {
+	return [[self class] routeURL:URL withController:self parameters:nil executeBlock:NO];
+}
+
+- (BOOL)canRouteURL:(NSURL *)URL withParameters:(NSDictionary *)parameters {
+	return [[self class] routeURL:URL withController:self parameters:parameters executeBlock:NO];
+}
 
 #pragma mark -
 #pragma mark Debugging Aids


### PR DESCRIPTION
Barista maintains routers for different types of requests (GET, POST, HEAD, DELETE, etc.). This patch adds support for routing to a specific router object.
