### PR TITLE
Allow non-singleton usage of JLRoutes class.

### DIFF
--- a/JLRoutes/JLRoutes.m
+++ b/JLRoutes/JLRoutes.m
@@ -338,7 +338,7 @@ static BOOL verboseLoggingEnabled = NO;
 			[finalParameters addEntriesFromDictionary:parameters];
 			finalParameters[kJLRoutePatternKey] = route.pattern;
 			finalParameters[kJLRouteURLKey] = URL;
-			finalParameters[kJLRouteNamespaceKey] = route.parentRoutesController.namespaceKey;
+			finalParameters[kJLRouteNamespaceKey] = route.parentRoutesController.namespaceKey ?: [NSNull null];
 
 			[self verboseLogWithFormat:@"Final parameters are %@", finalParameters];
 			didRoute = route.block(finalParameters);

--- a/JLRoutesTests/JLRoutesTests.m
+++ b/JLRoutesTests/JLRoutesTests.m
@@ -267,6 +267,14 @@ static JLRoutesTests *testsInstance = nil;
   STAssertTrue([JLRoutes canRouteURL:shouldHaveRouteURL], @"Should state it can route known URL");
 }
 
+- (void)testNonSingletonUsage
+{
+    JLRoutes *routes = [JLRoutes new];
+    NSURL *trivialURL = [NSURL URLWithString:@"/success"];
+    [routes addRoute:[trivialURL absoluteString] handler:nil];
+    STAssertTrue([routes routeURL:trivialURL], @"Non-singleton instance should route known URL");
+}
+
 #pragma mark -
 #pragma mark Convenience Methods
 


### PR DESCRIPTION
There's no public API for the namespaceKey, so instances can't be expected to set or implement the property. Though if you're using a non-singleton JLRoutes object, the namespace is probably irrelevant.

(I realize this is non-standard usage of JLRoutes, but I can't think of a reason why it shouldn't work.)
