### PR TITLE
Use warning-free format specifier for NSUInteger.

### DIFF
--- a/JLRoutes/JLRoutes.m
+++ b/JLRoutes/JLRoutes.m
@@ -125,7 +125,7 @@ static BOOL verboseLoggingEnabled = NO;
 
 
 - (NSString *)description {
-	return [NSString stringWithFormat:@"JLRoute %@ (%i)", self.pattern, self.priority];
+	return [NSString stringWithFormat:@"JLRoute %@ (%tu)", self.pattern, self.priority];
 }
 
 


### PR DESCRIPTION
The warning cropped up for me when building for arm64.
