### PR TITLE
Makes it easier to subclass.

### DIFF
--- a/JLRoutes/JLRoutes.m
+++ b/JLRoutes/JLRoutes.m
@@ -175,7 +175,7 @@ static BOOL shouldDecodePlusSymbols = YES;
 	});
 	
 	if (!routeControllersMap[scheme]) {
-		routesController = [[JLRoutes alloc] init];
+		routesController = [[self alloc] init];
 		routesController.namespaceKey = scheme;
 		routeControllersMap[scheme] = routesController;
 	}


### PR DESCRIPTION
I found that the routesForScheme method returned an instance of the superclass if you called it from a subclass, I have altered it to no longer do this.
