### PR TITLE
Add versions of the route-adding methods that include a "validator" block.

### DIFF
--- a/JLRoutes.podspec
+++ b/JLRoutes.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "JLRoutes"
-  s.version      = "1.5.2"
+  s.version      = "1.6.0"
   s.summary      = "Advanced URL parsing designed to handle complex URL schemes with a block-based callback API."
   s.homepage     = "https://github.com/joeldev/JLRoutes"
 

--- a/JLRoutes.podspec
+++ b/JLRoutes.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   }
 
   s.author       = { "Joel Levin" => "joel@joeldev.com" }
-  s.source       = { :git => "https://github.com/joeldev/JLRoutes.git", :tag => "1.5.2" }
+  s.source       = { :git => "https://github.com/joeldev/JLRoutes.git", :tag => s.version.to_s }
 
   s.source_files = 'JLRoutes', 'JLRoutes/*.{h,m}'
   s.framework  = 'Foundation'

--- a/JLRoutes/JLRoutes.h
+++ b/JLRoutes/JLRoutes.h
@@ -19,6 +19,7 @@ static NSString *const kJLRouteNamespaceKey = @"JLRouteNamespace";
 static NSString *const kJLRouteWildcardComponentsKey = @"JLRouteWildcardComponents";
 static NSString *const kJLRoutesGlobalNamespaceKey = @"JLRoutesGlobalNamespace";
 
+typedef BOOL(^JLRoutesHandler)(NSDictionary *parameters);
 
 @interface JLRoutes : NSObject
 /** @class JLRoutes
@@ -36,8 +37,14 @@ static NSString *const kJLRoutesGlobalNamespaceKey = @"JLRoutesGlobalNamespace";
 + (BOOL)shouldDecodePlusSymbols;
 
 /// Registers a routePattern with default priority (0) in the receiving scheme namespace.
-+ (void)addRoute:(NSString *)routePattern handler:(BOOL (^)(NSDictionary *parameters))handlerBlock;
-- (void)addRoute:(NSString *)routePattern handler:(BOOL (^)(NSDictionary *parameters))handlerBlock; // instance method
++ (void)addRoute:(NSString *)routePattern handler:(JLRoutesHandler)handlerBlock;
+- (void)addRoute:(NSString *)routePattern handler:(JLRoutesHandler)handlerBlock; // instance method
++ (void)addRoute:(NSString *)routePattern
+       validator:(JLRoutesHandler)validatorBlock
+         handler:(JLRoutesHandler)handlerBlock;
+- (void)addRoute:(NSString *)routePattern
+       validator:(JLRoutesHandler)validatorBlock
+         handler:(JLRoutesHandler)handlerBlock; // instance method
 
 /// Removes a routePattern from the receiving scheme namespace.
 + (void)removeRoute:(NSString *)routePattern;
@@ -56,8 +63,16 @@ static NSString *const kJLRoutesGlobalNamespaceKey = @"JLRoutesGlobalNamespace";
 /// Registers a routePattern in the global scheme namespace with a handlerBlock to call when the route pattern is matched by a URL.
 /// The block returns a BOOL representing if the handlerBlock actually handled the route or not. If
 /// a block returns NO, JLRoutes will continue trying to find a matching route.
-+ (void)addRoute:(NSString *)routePattern priority:(NSUInteger)priority handler:(BOOL (^)(NSDictionary *parameters))handlerBlock;
-- (void)addRoute:(NSString *)routePattern priority:(NSUInteger)priority handler:(BOOL (^)(NSDictionary *parameters))handlerBlock; // instance method
++ (void)addRoute:(NSString *)routePattern priority:(NSUInteger)priority handler:(JLRoutesHandler)handlerBlock;
+- (void)addRoute:(NSString *)routePattern priority:(NSUInteger)priority handler:(JLRoutesHandler)handlerBlock; // instance method
++ (void)addRoute:(NSString *)routePattern
+        priority:(NSUInteger)priority
+       validator:(JLRoutesHandler)validatorBlock
+         handler:(JLRoutesHandler)handlerBlock;
+- (void)addRoute:(NSString *)routePattern
+        priority:(NSUInteger)priority
+       validator:(JLRoutesHandler)validatorBlock
+         handler:(JLRoutesHandler)handlerBlock; // instance method
 
 /// Routes a URL, calling handler blocks (for patterns that match URL) until one returns YES, optionally specifying add'l parameters
 + (BOOL)routeURL:(NSURL *)URL;

--- a/JLRoutes/JLRoutes.m
+++ b/JLRoutes/JLRoutes.m
@@ -109,9 +109,8 @@ static BOOL shouldDecodePlusSymbols = YES;
 				// this component is a variable
 				NSString *variableName = [patternComponent substringFromIndex:1];
 				NSString *variableValue = URLComponent;
-				NSString *urlDecodedVariableValue = [variableValue JLRoutes_URLDecodedString];
-				if ([variableName length] > 0 && [urlDecodedVariableValue length] > 0) {
-					variables[variableName] = urlDecodedVariableValue;
+				if (variableName.length && variableValue.length) {
+					variables[variableName] = variableValue;
 				}
 			} else if ([patternComponent isEqualToString:@"*"]) {
 				// match wildcards


### PR DESCRIPTION
If present, the validator block is run during route-matching, if a route appears to match based on the pattern. If the validator returns `YES`, the route is considered a match; if the validator returns `NO`, the route is not considered a match.