### PR TITLE
Fixed a crash caused by variable empty & wildcard still allowing it.

### DIFF
--- a/JLRoutes/JLRoutes.m
+++ b/JLRoutes/JLRoutes.m
@@ -112,6 +112,11 @@ static BOOL shouldDecodePlusSymbols = YES;
 				if ([variableName length] > 0 && [urlDecodedVariableValue length] > 0) {
 					variables[variableName] = urlDecodedVariableValue;
 				}
+                else {
+                    NSMutableArray * newComponents = [NSMutableArray arrayWithArray:URLComponents];
+                    [newComponents addObject:@""];
+                    URLComponents = newComponents;
+                }
 			} else if ([patternComponent isEqualToString:@"*"]) {
 				// match wildcards
 				variables[kJLRouteWildcardComponentsKey] = [URLComponents subarrayWithRange:NSMakeRange(componentIndex, URLComponents.count-componentIndex)];

--- a/JLRoutesTests/JLRoutesTests.m
+++ b/JLRoutesTests/JLRoutesTests.m
@@ -432,6 +432,12 @@ static JLRoutesTests *testsInstance = nil;
 	[JLRoutes setShouldDecodePlusSymbols:oldDecodeSetting];
 }
 
+- (void) testVariableEmptyFollowedByWildcard {
+    [[JLRoutes routesForScheme:@"wildcardTests"] addRoute:@"list/:variable/detail/:variable2/*" handler:nil];
+    [self route:@"wildcardTests://list/variable/detail/"];
+    JLValidateAnyRouteMatched();
+}
+
 #pragma mark -
 #pragma mark Convenience Methods
 


### PR DESCRIPTION
There was a crash due to NSRange exception
Let's say a route `something/:variable/detail/:variable2/*` has been added.
Then, you try to open the app with `myapp://something/variable/detail/`
This used to crash because of a Out of Range because the wildcard was protecting the :variable2 from being empty.

Now, the variable2 will be en empty string and added in the URLComponents. This might now be the most elegant way to fix it but it works. I'm open to discuss it if there's a more elegant fix.