### PR TITLE
Removed backward compatibility to support Universal Links

### DIFF
--- a/JLRoutes/JLRoutes.m
+++ b/JLRoutes/JLRoutes.m
@@ -403,13 +403,7 @@ static BOOL shouldDecodePlusSymbols = YES;
 
 	// break the URL down into path components and filter out any leading/trailing slashes from it
 	NSArray *pathComponents = [(URL.pathComponents ?: @[]) filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"NOT SELF like '/'"]];
-	
-	if ([URL.host rangeOfString:@"."].location == NSNotFound && ![URL.host isEqualToString:@"localhost"]) {
-		// For backward compatibility, handle scheme://path/to/ressource as if path was part of the
-		// path if it doesn't look like a domain name (no dot in it)
-		pathComponents = [@[URL.host] arrayByAddingObjectsFromArray:pathComponents];
-	}
-	
+
 	[self verboseLogWithFormat:@"URL path components: %@", pathComponents];
 	
 	for (_JLRoute *route in routes) {


### PR DESCRIPTION
Hi,

I ran into a matching problem with a URL that looked like this:
````
myapp://invite.myapp.com/:inviteId
````

Found the problem in the code I have deleted. I don't fully understand what the code was doing that I deleted, but it seems to work for me. Wanted to send this to you if you thought it was something old that could be removed. 

With universal links in iOS 9 I think dots in the urls is going to be a lot more common.