### PR TITLE
Feature/add optionals

### DIFF
--- a/JLRoutes/JLRoutes.m
+++ b/JLRoutes/JLRoutes.m
@@ -95,8 +95,6 @@ static BOOL shouldDecodePlusSymbols = YES;
 	}
 	
 	// do a quick component count check to quickly eliminate incorrect patterns
-    self.pattern = [self.pattern stringByReplacingOccurrencesOfString:@"(" withString:@""];
-    self.pattern = [self.pattern stringByReplacingOccurrencesOfString:@")" withString:@""];
 	BOOL componentCountEqual = self.patternPathComponents.count == URLComponents.count;
 	BOOL routeContainsWildcard = !NSEqualRanges([self.pattern rangeOfString:@"*"], NSMakeRange(NSNotFound, 0));
 	if (componentCountEqual || routeContainsWildcard) {

--- a/JLRoutesTests/JLRoutesTests.m
+++ b/JLRoutesTests/JLRoutesTests.m
@@ -65,6 +65,7 @@ static JLRoutesTests *testsInstance = nil;
 	[JLRoutes addRoute:@"/interleaving/:param1/foo/:param2" handler:defaultHandler];
 	[JLRoutes addRoute:@"/xyz/wildcard/*" handler:defaultHandler];
 	[JLRoutes addRoute:@"/route/:param/*" handler:defaultHandler];
+    [JLRoutes addRoute:@"/required/:requiredParam(/optional/:optionalParam)(/moreOptional/:moreOptionalParam)" handler:defaultHandler];
     
     // used in testMultiple
     [JLRoutes addRoutes:@[@"/multiple1", @"/multiple2"] handler:defaultHandler];
@@ -210,6 +211,24 @@ static JLRoutesTests *testsInstance = nil;
     JLValidateAnyRouteMatched();
     JLValidatePattern(@"/test");
     JLValidateParameterCount(0);
+    
+    [self route:@"tests://required/mustExist"];
+    JLValidateAnyRouteMatched();
+    JLValidateParameterCount(1);
+    JLValidateParameter(@{@"requiredParam": @"mustExist"});
+    
+    [self route:@"tests://required/mustExist/optional/mightExist"];    
+    JLValidateAnyRouteMatched();
+    JLValidateParameterCount(2);
+    JLValidateParameter(@{@"requiredParam": @"mustExist"});
+    JLValidateParameter(@{@"optionalParam": @"mightExist"});
+    
+    [self route:@"tests://required/mustExist/optional/mightExist/moreOptional/mightExistToo"];
+    JLValidateAnyRouteMatched();
+    JLValidateParameterCount(3);
+    JLValidateParameter(@{@"requiredParam": @"mustExist"});
+    JLValidateParameter(@{@"optionalParam": @"mightExist"});
+    JLValidateParameter(@{@"moreOptionalParam": @"mightExistToo"});
 }
 
 - (void)testMultiple {

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ This tells JLRoutes that if a URL cannot be routed within the namespace `thing` 
 
 JLRoutes supports setting up routes that will match an arbitrary number of path components at the end of the routed URL. An array containing the additional path components will be added to the parameters dictionary with the key `kJLRouteWildcardComponentsKey`.
 
-For example, the following route would be triggerd for any URL that started with `/wildcard/`, but would be rejected by the handler if the next component wasn't `joker`.
+For example, the following route would be triggered for any URL that started with `/wildcard/`, but would be rejected by the handler if the next component wasn't `joker`.
 
 ```objc
 [JLRoutes addRoute:@"/wildcard/*" handler:^BOOL(NSDictionary *parameters) {
@@ -173,7 +173,17 @@ For example, the following route would be triggerd for any URL that started with
 	// not interested unless the joker's in it
 	return NO;
 }];
-```
+```    
+
+
+### Optional routes ###
+
+JLRoutes supports setting up routes with optional parameters. At the route registration moment, JLRoute will register multiple routes with all combinations of the route with the optional parameters and without the optional parameters. For example, for the route `/user/:userId(/post/:postId)(/reply/:replyId)`, it will register the following routes:
+
+- `/user/:userId/post/:postId/reply/:replyId`
+- `/user/:userId/post/:postId/`
+- `/user/:userId`
+
 
 ### License ###
 BSD 3-Clause License:


### PR DESCRIPTION
Implemented functionality to register optional parameters (similar to ruby paths). If a route that include parenthesis is registered, it will consider what's between parenthesis optional, and create a combination of routes with and without the parenthesis. All the work happens during the route registration, and not during route handling.

Ex.: `/user/:userId(/post/:postId)(/reply/:replyId)` will match the following:
- `/user/:userId/post/:postId/reply/:replyId`
- `/user/:userId/post/:postId/`
- `/user/:userId`                               