### PR TITLE
application:openURL:sourceApplication:annotation deprecation in iOS 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ JLRoutes is available for installation via CocoaPods.
   return YES;
 }
 
-- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation {
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString *, id> *)options {
   return [JLRoutes routeURL:url];
 }
 ```


### PR DESCRIPTION
` - application:openURL:sourceApplication:annotation: ` has been deprecated in favour of 
`- application:openURL:options:`