### PR TITLE
Add support for fragment routing

### DIFF
--- a/JLRoutesTests/JLRoutesTests.m
+++ b/JLRoutesTests/JLRoutesTests.m
@@ -327,12 +327,12 @@ static JLRoutesTests *testsInstance = nil;
     [self route:@"tests://doesnt/exist#/and/wont/match"];
     JLValidateNoLastMatch();
     
-    [self route:@"tests://required/mustExist"];
+    [self route:@"tests://required#/mustExist"];
     JLValidateAnyRouteMatched();
     JLValidateParameterCount(1);
     JLValidateParameter(@{@"requiredParam": @"mustExist"});
     
-    [self route:@"tests://required/mustExist/optional/mightExist"];
+    [self route:@"tests://required#/mustExist/optional/mightExist"];
     JLValidateAnyRouteMatched();
     JLValidateParameterCount(2);
     JLValidateParameter(@{@"requiredParam": @"mustExist"});


### PR DESCRIPTION
Hi Joel,

This pull request adds support for fragment routing. For example, the ability to route a URL like:
`/$chat.do#/conversation/123`

It also adds additional fragment parameter support. For example:
`/$chat.do#/conversation/123?active=true`

All of the fragment parameter parsing added in https://github.com/joeldev/JLRoutes/pull/16 still works as expected and I've added new tests for the new fragment routing and parameter parsing.

Route patterns with `#` in the pattern are opted in to this new routing / parameter parsing automatically.

Thanks so much for this library! I appreciate you considering this PR and I'm more than happy to make changes if there's anything you'd like adjusted.

Thanks for your time!