### PR TITLE
Add missing imports

### DIFF
--- a/JLRoutes/JLRoutes.h
+++ b/JLRoutes/JLRoutes.h
@@ -12,11 +12,12 @@
 
 #import <Foundation/Foundation.h>
 
+#import "JLRRouteDefinition.h"
+#import "JLRRouteHandler.h"
+#import "JLRRouteRequest.h"
+#import "JLRRouteResponse.h"
+
 NS_ASSUME_NONNULL_BEGIN
-
-
-@class JLRRouteDefinition;
-
 
 /// The matching route pattern, passed in the handler parameters.
 extern NSString *const JLRoutePatternKey;


### PR DESCRIPTION
Fixes “Umbrella header for 'JLRoutes' does not include header ...” warnings when including JLRoutes in a Swift project.