### PR TITLE
check for zero length pattern

### DIFF
--- a/JLRoutes/Classes/JLRRouteDefinition.m
+++ b/JLRoutes/Classes/JLRRouteDefinition.m
@@ -37,7 +37,7 @@
         self.priority = priority;
         self.handlerBlock = handlerBlock;
         
-        if ([pattern characterAtIndex:0] == '/') {
+        if ([pattern length] > 0 && [pattern characterAtIndex:0] == '/') {
             pattern = [pattern substringFromIndex:1];
         }
         


### PR DESCRIPTION
If you pass `""` as a pattern (which has been working blissfully for years) the route definition will blow up under xocde 10 beta 6 with a range out of bounds exception.