### PR TITLE
Increment Swift version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version: 5.4
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.4
+// swift-tools-version:5.4
 
 import PackageDescription
 


### PR DESCRIPTION
In Swift 5.7, a new feature called [module aliasing](https://github.com/apple/swift-evolution/blob/main/proposals/0339-module-aliasing-for-disambiguation.md) that allows us to have multiple modules with the same name changing these names by an alias. If we want to use this module aliasing feature, the packages of your project's dependencies need to be Swift 5.4 version or over to compile.
So I would like to propose incrementing the Swift version to 5.4